### PR TITLE
`chat_cortex_analyst()` is now deprecated; please use `chat_snowflake()` instead (#640).

### DIFF
--- a/R/utils-ellmer.R
+++ b/R/utils-ellmer.R
@@ -20,7 +20,6 @@ chat_ellmer <- \(provider = "ollama"){
     "claude"           = ellmer::chat_claude,
     "cloudfare"        = ellmer::chat_cloudflare,
     "cortex"           = ellmer::chat_cortex,
-    "cortex_analyst"   = ellmer::chat_cortex_analyst,
     "databricks"       = ellmer::chat_databricks,
     "deepseek"         = ellmer::chat_deepseek,
     "gemini"           = ellmer::chat_gemini,

--- a/vignettes/cloud-providers.qmd
+++ b/vignettes/cloud-providers.qmd
@@ -99,7 +99,6 @@ chat_providers <- data.frame(
     "ellmer::chat_claude",
     "ellmer::chat_cloudflare",
     "ellmer::chat_cortex",
-    "ellmer::chat_cortex_analyst",
     "ellmer::chat_databricks",
     "ellmer::chat_deepseek",
     "ellmer::chat_gemini",


### PR DESCRIPTION
See https://github.com/tidyverse/ellmer/blob/main/NEWS.md

Error:
! 'chat_cortex_analyst' is not an exported object from 'namespace:ellmer'
Hide Traceback
    ▆
 1. └─kuzco::llm_image_recognition(...)
 2.   └─kuzco:::ellmer_image_recognition(...)
 3.     └─kuzco:::chat_ellmer(provider = provider)